### PR TITLE
 Nautilus dark theme floating-bar is missing solid background  - EOS

### DIFF
--- a/gtk-3.0/apps.css
+++ b/gtk-3.0/apps.css
@@ -100,7 +100,24 @@ dialog entry.pathbar:focus {
 * Nautilus FLoatbar *
 ********************/
 
+.floating-bar {
+    background-color: alpha (#232837, 0.9);
+    border-radius: 3px;
+    border-width: 0;
+	border: 1px solid #3D4248; /* Better visual */
+    box-shadow:
+        0 1px 3px alpha (#000, 0.50), /* Tested 7 times for better resualt */
+        0 1px 2px alpha (#000, 0.24);
+    color: #fff;
+    padding: 2px 0;
+    margin: 6px;
+    text-shadow: 0 1px 2px alpha (#000, 0.6);
+}
 
+.floating-bar label {
+    color: #fff;
+    text-shadow: 0 1px 2px alpha (#000, 0.6);
+}
 
 /*******
 * Gala *

--- a/gtk-3.0/apps.css
+++ b/gtk-3.0/apps.css
@@ -96,6 +96,12 @@ dialog entry.pathbar:focus {
         0 1px 0 0 alpha (shade (@colorPrimary, 1.4), 0.5);
 }
 
+/********************
+* Nautilus FLoatbar *
+********************/
+
+
+
 /*******
 * Gala *
 *******/


### PR DESCRIPTION
If we set theme to Elementary X nautilus file manager - status bar is transparent and make readability to zero.

It's **floated bar** for status in nautilus

Also merged with background context like file name and other things in background this make user confused.

This add some CSS style to that part.

> Before these changes

![T2250](https://user-images.githubusercontent.com/8873215/68430559-8339a680-01c5-11ea-96e8-b41ab3a7c781.png)

> After these changes

![d2250](https://user-images.githubusercontent.com/8873215/68430594-964c7680-01c5-11ea-8116-c4edbecdd49b.png)

**Note :** 

I don't test it with light theme

But It should work either on light cause ``alpha background`` It's not below ``0.5``
