### PR TITLE
Go back to home folder, before attempting to delete the Git folder

### DIFF
--- a/install_plank_themes.sh
+++ b/install_plank_themes.sh
@@ -1,4 +1,5 @@
 git clone https://github.com/surajmandalcell/plank-themes.git 
 cd plank-themes
 cp -r themes/* ~/.local/share/plank/themes
-rm -rf plank
+cd
+rm -rf plank-themes

--- a/install_plank_themes.sh
+++ b/install_plank_themes.sh
@@ -1,5 +1,5 @@
 git clone https://github.com/surajmandalcell/plank-themes.git 
 cd plank-themes
 cp -r themes/* ~/.local/share/plank/themes
-cd
+cd ..
 rm -rf plank-themes


### PR DESCRIPTION
Currently, at the third line, we are in ~/plank_themes when we move the content of themes to ~/.local/share/plank/themes
However, you didn´t go back to the ~/ folder, where the actual plank_theme folder is situated.
So, I´ve added `cd` to go back here.
I´ve also modified the folder to erase to `plank-themes` as it is like this, it is called.
![](https://framapic.org/icAfi5WLtQnZ/K6X0s0nRRocm.png)